### PR TITLE
Everything should work this time

### DIFF
--- a/gears.scad
+++ b/gears.scad
@@ -1,27 +1,29 @@
-$fn = 200;
+$fn = 96;
 
 /* Library for Involute Gears, Screws and Racks
 
 This library contains the following modules
-- rack(modul, length, height, width, pressure_angle, helix_angle)
-- herringbone_rack(modul, length, height, width, pressure_angle, helix_angle)
-- spur_gear(modul, tooth_number, width, bore, pressure_angle, helix_angle, optimized)
-- herringbone_gear(modul, tooth_number, width, bore, pressure_angle, helix_angle, optimized)
-- rack_and_pinion (modul, rack_length, gear_teeth, rack_height, gear_bore, width, pressure_angle, helix_angle, together_built, optimized)
-- ring_gear(modul, tooth_number, width, rim_width, pressure_angle, helix_angle)
-- herringbone_ring_gear(modul, tooth_number, width, rim_width, pressure_angle, helix_angle)
-- planetary_gear(modul, sun_teeth, planet_teeth, number_planets, width, rim_width, bore, pressure_angle, helix_angle, together_built, optimized)
-- bevel_gear(modul, tooth_number, partial_cone_angle, tooth_width, bore, pressure_angle, helix_angle)
-- bevel_herringbone_gear(modul, tooth_number, partial_cone_angle, tooth_width, bore, pressure_angle, helix_angle)
-- bevel_gear_pair(modul, gear_teeth, pinion_teeth, axis_angle, tooth_width, bore, pressure_angle, helix_angle, together_built)
-- bevel_herringbone_gear_pair(modul, gear_teeth, pinion_teeth, axis_angle, tooth_width, bore, pressure_angle, helix_angle, together_built)
-- worm(modul, thread_starts, length, bore, pressure_angle, lead_angle, together_built)
-- worm_gear(modul, tooth_number, thread_starts, width, length, worm_bore, gear_bore, pressure_angle, lead_angle, optimized, together_built)
+- rack(modul, length, height, width, pressure_angle=20, helix_angle=0)
+- mountable_rack(modul, length, height, width, pressure_angle=20, helix_angle=0, fastners, profile, head)
+- herringbone_rack(modul, length, height, width, pressure_angle = 20, helix_angle=45)
+- mountable_herringbone_rack(modul, length, height, width, pressure_angle=20, helix_angle=45, fastners, profile, head) 
+- spur_gear(modul, tooth_number, width, bore, pressure_angle=20, helix_angle=0, optimized=true)
+- herringbone_gear(modul, tooth_number, width, bore, pressure_angle=20, helix_angle=0, optimized=true)
+- rack_and_pinion (modul, rack_length, gear_teeth, rack_height, gear_bore, width, pressure_angle=20, helix_angle=0, together_built=true, optimized=true)
+- ring_gear(modul, tooth_number, width, rim_width, pressure_angle=20, helix_angle=0)
+- herringbone_ring_gear(modul, tooth_number, width, rim_width, pressure_angle=20, helix_angle=0)
+- planetary_gear(modul, sun_teeth, planet_teeth, number_planets, width, rim_width, bore, pressure_angle=20, helix_angle=0, together_built=true, optimized=true)
+- bevel_gear(modul, tooth_number,  partial_cone_angle, tooth_width, bore, pressure_angle=20, helix_angle=0)
+- bevel_herringbone_gear(modul, tooth_number, partial_cone_angle, tooth_width, bore, pressure_angle=20, helix_angle=0)
+- bevel_gear_pair(modul, gear_teeth, pinion_teeth, axis_angle=90, tooth_width, bore, pressure_angle = 20, helix_angle=0, together_built=true)
+- bevel_herringbone_gear_pair(modul, gear_teeth, pinion_teeth, axis_angle=90, tooth_width, bore, pressure_angle = 20, helix_angle=0, together_built=true)
+- worm(modul, thread_starts, length, bore, pressure_angle=20, lead_angle=10, together_built=true)
+- worm_gear(modul, tooth_number, thread_starts, width, length, worm_bore, gear_bore, pressure_angle=20, lead_angle=0, optimized=true, together_built=true)
 
 Examples of each module are commented out at the end of this file
 
-Lead Author:      Dr Jörg Janssen
-Contributions By: Keith Emery,
+Author:     Dr Jörg Janssen
+Contributions By:   Keith Emery, Chris Spencer
 Last Verified On:      1. June 2018
 Version:    2.2
 License:     Creative Commons - Attribution, Non Commercial, Share Alike
@@ -95,10 +97,10 @@ function spiral(a, r0, phi) =
     a*phi + r0; 
 
 /*  Copy and rotate a Body */
-module copier(vect, number, distance, corner){
+module copier(vect, number, distance, winkel){
     for(i = [0:number-1]){
         translate(v=vect*distance*i)
-            rotate(a=i*corner, v = [0,0,1])
+            rotate(a=i*winkel, v = [0,0,1])
                 children(0);
     }
 }
@@ -145,6 +147,77 @@ module rack(modul, length, height, width, pressure_angle = 20, helix_angle = 0) 
         };
     };  
 }
+
+/* Mountable-rack; uses module "rack"
+    modul = Height of the Tooth Tip above the Rolling LIne
+    length = Length of the Rack
+    height = Height of the Rack to the Pitch Line
+    width = Width of a Tooth
+    pressure_angle = Pressure Angle, Standard = 20° according to DIN 867. Should not exceed 45°.
+    helix_angle = Helix Angle of the Rack Transverse Axis; 0° = Spur Teeth 
+    fastners = Total number of fastners.
+    profile = Metric standard profile for fastners (ISO machine screws), M4 = 4, M6 = 6 etc.
+    
+    head = Style of fastner to accomodate.
+    PH = Pan Head, C = Countersunk, RC = Raised Countersunk, CS = Cap Screw, CSS = Countersunk Socket Screw. */
+module mountable_rack(modul, length, height, width, pressure_angle, helix_angle, fastners, profile, head) {
+    difference(){
+    rack(modul, length, height, width, pressure_angle, helix_angle);
+    offset = (length/fastners);
+    translate([-length/2+(offset/2),0,0])
+    for(i = [0:fastners-1]){
+                if (head=="PH"){
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=height+modul, d=profile, center=false);
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=profile*0.6+modul*2.25, d=profile*2, center=false);
+                    }
+                if (head=="CS"){
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=height+modul, d=profile, center=false);
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=profile*1.25+modul*2.25, d=profile*1.5, center=false);
+                    }
+                if (head=="C"){
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=height+modul, d=profile, center=false);
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=modul*2.25, d=profile*2, center=false);
+                    translate([i*offset,-modul*1.25,width/2])
+                    rotate([90,0,0])
+                    cylinder (h=profile/2, d1=profile*2, d2=profile, center=false);
+                    }
+                if (head=="RC"){
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=height+modul, d=profile, center=false);
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=modul*2.25+profile/4, d=profile*2, center=false);
+                    translate([i*offset,-modul*1.25-profile/4,width/2])
+                    rotate([90,0,0])
+                    cylinder (h=profile/2, d1=profile*2, d2=profile, center=false);
+                    }
+                if (head=="CSS"){
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=height+modul, d=profile, center=false);
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=modul*2.25, d=profile*2, center=false);
+                    translate([i*offset,-modul*1.25,width/2])
+                    rotate([90,0,0])
+                    cylinder (h=profile*0.6, d1=profile*2, d2=profile, center=false);
+                    }
+                } 
+            }
+        }
 
 /*  Spur gear
     modul = Height of the Tooth Tip beyond the Pitch Circle
@@ -268,6 +341,77 @@ module herringbone_rack(modul, length, height, width, pressure_angle = 20, helix
         }
     }
 }
+
+/* Mountable_herringbone_rack; uses module "herringbone_rack"
+    modul = Height of the Tooth Tip above the Rolling LIne
+    length = Length of the Rack
+    height = Height of the Rack to the Pitch Line
+    width = Width of a Tooth
+    pressure_angle = Pressure Angle, Standard = 20° according to DIN 867. Should not exceed 45°.
+    helix_angle = Helix Angle of the Rack Transverse Axis; 0° = Spur Teeth 
+    fastners = Total number of fastners.
+    profile = Metric standard profile for fastners (ISO machine screws), M4 = 4, M6 = 6 etc.
+    
+    head = Style of fastner to accomodate.
+    PH = Pan Head, C = Countersunk, RC = Raised Countersunk, CS = Cap Screw, CSS = Countersunk Socket Screw. */
+module mountable_herringbone_rack(modul, length, height, width, pressure_angle, helix_angle, fastners, profile, head) {
+    difference(){
+    herringbone_rack(modul, length, height, width, pressure_angle, helix_angle);
+    offset = (length/fastners);
+    translate([-length/2+(offset/2),0,0])
+    for(i = [0:fastners-1]){
+                if (head=="PH"){
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=height+modul, d=profile, center=false);
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=profile*0.6+modul*2.25, d=profile*2, center=false);
+                    }
+                if (head=="CS"){
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=height+modul, d=profile, center=false);
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=profile*1.25+modul*2.25, d=profile*1.5, center=false);
+                    }
+                if (head=="C"){
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=height+modul, d=profile, center=false);
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=modul*2.25, d=profile*2, center=false);
+                    translate([i*offset,-modul*1.25,width/2])
+                    rotate([90,0,0])
+                    cylinder (h=profile/2, d1=profile*2, d2=profile, center=false);
+                    }
+                if (head=="RC"){
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=height+modul, d=profile, center=false);
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=modul*2.25+profile/4, d=profile*2, center=false);
+                    translate([i*offset,-modul*1.25-profile/4,width/2])
+                    rotate([90,0,0])
+                    cylinder (h=profile/2, d1=profile*2, d2=profile, center=false);
+                    }
+                if (head=="CSS"){
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=height+modul, d=profile, center=false);
+                    translate([i*offset,modul,width/2])
+                    rotate([90,0,0])
+                    cylinder(h=modul*2.25, d=profile*2, center=false);
+                    translate([i*offset,-modul*1.25,width/2])
+                    rotate([90,0,0])
+                    cylinder (h=profile*0.6, d1=profile*2, d2=profile, center=false);
+                    }
+                } 
+            }
+        }
 
 /* Herringbone_gear; uses the module "spur_gear"
     modul = Height of the Tooth Tip beyond the Pitch Circle
@@ -918,83 +1062,14 @@ module worm_gear(modul, tooth_number, thread_starts, width, length, worm_bore, g
     }
 }
 
-/* Mountable-rack; uses module "rack"
-    modul = Height of the Tooth Tip above the Rolling LIne
-    length = Length of the Rack
-    height = Height of the Rack to the Pitch Line
-    width = Width of a Tooth
-    pressure_angle = Pressure Angle, Standard = 20° according to DIN 867. Should not exceed 45°.
-    helix_angle = Helix Angle of the Rack Transverse Axis; 0° = Spur Teeth 
-    rows = Rows of fastners.  Generally this will be one row, but very wide racks may require more.
-    columbs = Columbs of fastners.  For a single row of 4 fastners, specify 1 row, 4 columbs, etc.
-    profile = Metric standard profile for machine screws, M4 = 4, M6 = 6 etc.
-    
-    head = Style of machine screw to accomodate.
-    PH = Pan Head, C = Countersunk, RC = Raised Countersunk, CS = Cap Screw, CSS = Countersunk Socket Screw. */
-module mountable_rack (modul, length, height, width, pressure_angle, helix_angle, rows, columbs, profile, head) {
-    difference() {
-        rack(modul, length, height, width, pressure_angle, helix_angle);
-        columb_spacing = columbs+1/length;
-        for ( i = [-(length/2) : columb_spacing : columbs] ){                
-        translate([columb_spacing, 0, 0])
-        if (head=="PH"){
-                translate([0,modul,width/2])
-                rotate([90,0,0])
-                cylinder(h=height+modul, d=profile, center=false);
-                translate([0,modul,width/2])
-                rotate([90,0,0])
-                cylinder(h=profile*0.6+modul*2.25, d=profile*2, center=false);
-            }
-        if (head=="CS"){
-                translate([0,modul,width/2])
-                rotate([90,0,0])
-                cylinder(h=height+modul, d=profile, center=false);
-                translate([0,modul,width/2])
-                rotate([90,0,0])
-                cylinder(h=profile*1.25+modul*2.25, d=profile*1.5, center=false);
-            }
-        if (head=="C"){
-                translate([0,modul,width/2])
-                rotate([90,0,0])
-                cylinder(h=height+modul, d=profile, center=false);
-                translate([0,modul,width/2])
-                rotate([90,0,0])
-                cylinder(h=modul*2.25, d=profile*2, center=false);
-                translate([0,-modul*1.25,width/2])
-                rotate([90,0,0])
-                cylinder (h=profile/2, d1=profile*2, d2=profile, center=false);
-            }
-        if (head=="RC"){
-                translate([0,modul,width/2])
-                rotate([90,0,0])
-                cylinder(h=height+modul, d=profile, center=false);
-                translate([0,modul,width/2])
-                rotate([90,0,0])
-                cylinder(h=modul*2.25+profile/4, d=profile*2, center=false);
-                translate([0,-modul*1.25-profile/4,width/2])
-                rotate([90,0,0])
-                cylinder (h=profile/2, d1=profile*2, d2=profile, center=false);
-            }
-        if (head=="CSS"){
-                translate([0,modul,width/2])
-                rotate([90,0,0])
-                cylinder(h=height+modul, d=profile, center=false);
-                translate([0,modul,width/2])
-                rotate([90,0,0])
-                cylinder(h=modul*2.25, d=profile*2, center=false);
-                translate([0,-modul*1.25,width/2])
-                rotate([90,0,0])
-                cylinder (h=profile*0.6, d1=profile*2, d2=profile, center=false);
-                }
-           }
-      }
- }
 
-mountable_rack(modul=1, length=40, height=10, width=20, pressure_angle=20, helix_angle=0, profile=3, head="CS",columbs=2);
+//rack(modul=1, length=60, height=5, width=20, pressure_angle=20, helix_angle=0);
 
-//rack(modul=1, length=30, height=5, width=20, pressure_angle=20, helix_angle=0);
+//mountable_rack(modul=1, length=60, height=5, width=20, pressure_angle=20, helix_angle=0, profile=3, head="PH",fastners=3);
 
-//herringbone_rack(modul=1, length=60, height=5, width=10, pressure_angle=20, helix_angle=45);
+//herringbone_rack(modul=1, length=60, height=5, width=20, pressure_angle=20, helix_angle=45);
+
+mountable_herringbone_rack(modul=1, length=60, height=5, width=20, pressure_angle=20, helix_angle=45, profile=3, head="PH",fastners=3);
 
 //spur_gear (modul=1, tooth_number=30, width=5, bore=4, pressure_angle=20, helix_angle=20, optimized=true);
 


### PR DESCRIPTION
I've added two modules to generate fixture holes for both standard and herringbone racks.  Fixture holes can be generated to accommodate all standard ISO machine screws, except for cheese head.  Cheese head screws were not included as they make little sense in this application, they will however fit within a standard pan head fixture hole.